### PR TITLE
Insert opam\bin in PATH after DKML if that exists

### DIFF
--- a/assets/staging-files/win32/PathMods.Tests.ps1
+++ b/assets/staging-files/win32/PathMods.Tests.ps1
@@ -1,0 +1,63 @@
+# Upgrade Pester to be >= 4.6.0 using Administrator PowerShell:
+#   Install-Module -Name Pester -Force -SkipPublisherCheck
+
+# In VSCode just click "Run tests" below
+
+BeforeAll {
+    $dsc = [System.IO.Path]::DirectorySeparatorChar
+    if (Get-Module PathMods) {
+        Write-Host "Removing old PathMods module from PowerShell session"
+        Remove-Module PathMods
+    }
+    $env:PSModulePath += "$([System.IO.Path]::PathSeparator)${PSCommandPath}${dsc}.."
+    Import-Module PathMods
+}
+
+Describe 'Join-EnvPathEntry' {
+    It 'Always passes but displays the result of inserting opam\bin on this machine' {
+        if ($Env:DiskuvOCamlHome) {
+            $y = Join-EnvPathEntry `
+                -PathValue ([Environment]::GetEnvironmentVariable("PATH", "User")) `
+                -PathEntry $env:LOCALAPPDATA\Programs\opam\bin `
+                -MustBeAfterEntryIfExists $Env:DiskuvOCamlHome\bin
+            Write-Host "Effective PATH on this machine after Join-EnvPathEntry: $y"
+        }
+    }
+    It 'Given empty PATH the new PATH will be the single entry' {
+        $y = Join-EnvPathEntry -PathValue "" -PathEntry "C:\pester\item"
+        $y | Should -Be "C:\pester\item"
+    }
+    It 'Given empty PATH with -MustBeAfterEntryIfExists the new PATH will be the single entry' {
+        $y = Join-EnvPathEntry -PathValue "" -PathEntry "C:\pester\item" -MustBeAfterEntryIfExists "C:\pester\nonexistent"
+        $y | Should -Be "C:\pester\item"
+    }
+    It 'Given single-item PATH with -MustBeAfterEntryIfExists that exists the new PATH will have the new entry last' {
+        $y = Join-EnvPathEntry -PathValue "C:\pester\item" -PathEntry "C:\pester\anotheritem" -MustBeAfterEntryIfExists "C:\pester\item"
+        $y | Should -Be "C:\pester\item;C:\pester\anotheritem"
+    }
+    It 'Given two-item PATH with -MustBeAfterEntryIfExists that exists as the first item, then the new PATH will have the new entry in the middle' {
+        $y = Join-EnvPathEntry -PathValue "C:\pester\itemleft;C:\pester\itemright" -PathEntry "C:\pester\anotheritem" -MustBeAfterEntryIfExists "C:\pester\itemleft"
+        $y | Should -Be "C:\pester\itemleft;C:\pester\anotheritem;C:\pester\itemright"
+    }
+    It 'Given five-item PATH with -MustBeAfterEntryIfExists that exists as the second item, then the new PATH will have the new entry in the middle' {
+        $y = Join-EnvPathEntry `
+            -PathValue "C:\pester\itemleft1;C:\pester\itemleft2;C:\pester\itemright1;C:\pester\itemright2" `
+            -PathEntry "C:\pester\anotheritem" `
+            -MustBeAfterEntryIfExists "C:\pester\itemleft2"
+        $y | Should -Be "C:\pester\itemleft1;C:\pester\itemleft2;C:\pester\anotheritem;C:\pester\itemright1;C:\pester\itemright2"
+    }
+    It 'Given five-item PATH with -MustBeAfterEntryIfExists that exists as the second and third items, then the new PATH will have the new entry after the third' {
+        $y = Join-EnvPathEntry `
+            -PathValue "C:\pester\itemleft;C:\pester\itemsame;C:\pester\itemsame;C:\pester\itemright" `
+            -PathEntry "C:\pester\anotheritem" `
+            -MustBeAfterEntryIfExists "C:\pester\itemsame"
+        $y | Should -Be "C:\pester\itemleft;C:\pester\itemsame;C:\pester\itemsame;C:\pester\anotheritem;C:\pester\itemright"
+    }
+    It 'Given five-item PATH with -MustBeAfterEntryIfExists that does not exist, then the new PATH will have the new entry first' {
+        $y = Join-EnvPathEntry `
+            -PathValue "C:\pester\itemleft1;C:\pester\itemleft2;C:\pester\itemright1;C:\pester\itemright2" `
+            -PathEntry "C:\pester\anotheritem" `
+            -MustBeAfterEntryIfExists "C:\pester\nonexistent"
+        $y | Should -Be "C:\pester\anotheritem;C:\pester\itemleft1;C:\pester\itemleft2;C:\pester\itemright1;C:\pester\itemright2"
+    }
+}

--- a/assets/staging-files/win32/PathMods/PathMods.psm1
+++ b/assets/staging-files/win32/PathMods/PathMods.psm1
@@ -1,0 +1,126 @@
+# ======================
+# PathMods.psm1
+
+$ErrorActionPreference = "Stop"
+$splitter = [System.IO.Path]::PathSeparator # should be ';' if we are running on Windows (yes, you can run Powershell on other operating systems)
+
+if ((Get-Command New-Object).Parameters.Keys.Contains("ComObject")) {
+    # Only Windows has DOS 8.3 names
+    $fsobject = New-Object -ComObject Scripting.FileSystemObject
+} else {
+    $fsobject = $null
+}
+
+function Get-CurrentEpochMillis {
+    [long]$timestamp = [math]::Round((([datetime]::UtcNow) - (Get-Date -Date '1/1/1970')).TotalMilliseconds)
+    $timestamp
+}
+Export-ModuleMember -Function Get-CurrentEpochMillis
+
+function Get-Dos83ShortName {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Path
+    )
+    if ($null -ne $fsobject -and (Test-Path -Path $Path -PathType Container)) {
+        $output = $fsobject.GetFolder($Path)
+        $output.ShortPath
+    }
+    elseif ($null -ne $fsobject -and (Test-Path -Path $Path -PathType Leaf)) {
+        $output = $fsobject.GetFile($Path)
+        $output.ShortPath
+    }
+    else {
+        $Path
+    }
+}
+Export-ModuleMember -Function Get-Dos83ShortName
+
+# Join-EnvPathEntry
+# ------------
+#
+# Places the path entry (-PathEntry A) into the PATH User environment variable.
+#
+# If a -MustBeAfterEntryIfExists B is specified, and B exists in the PATH environment
+# variable, then:
+# 1. Any existing path entries A in PATH are removed.
+# 2. The path entry A will be placed immediately after path entry B.
+#
+# Otherwise:
+# 1. Any existing path entries A in PATH are removed.
+# 2. The path entry A is placed at the front of the PATH environment variable.
+#
+# Even if the path entry A already exists, it may be moved by using this
+# function.
+function Join-EnvPathEntry {
+    param (
+        [Parameter(Mandatory = $true)]
+        $PathValue,
+        [Parameter(Mandatory = $true)]
+        $PathEntry,
+        [Parameter()]
+        $MustBeAfterEntryIfExists
+    )
+
+    # all of the PATH as a collection
+    $pathEntries = $PathValue -split $splitter
+
+    # Edge case: $MustBeAfterEntryIfExists is a DOS 8.3 name but $PathValue
+    # contains full name
+    if ($MustBeAfterEntryIfExists -and (Test-Path $MustBeAfterEntryIfExists)) {
+        # Convert DOS 8.3 into a full name so that path search (Where-Object; see below)
+        # can find the full name (and the DOS 8.3).
+        $MustBeAfterEntryIfExists = (Get-Item -LiteralPath "$MustBeAfterEntryIfExists").FullName
+    }
+
+    # Remove any old path entry A
+    if ($PathValue -eq "") {
+        # Edge case: An empty PATH has no entries.
+        $pathEntries = [string[]] @()
+    }
+    else {
+        $pathEntries = $pathEntries | Where-Object { $_ -ne $PathEntry }
+        # fix bug-causing PowerShell (ex. PS 5) flattening of single element
+        if (-not ($pathEntries -is [array])) { $pathEntries = [string[]] @( $pathEntries ) }
+
+        $pathEntries = $pathEntries | Where-Object { $_ -ne (Get-Dos83ShortName $PathEntry) }
+        # fix bug-causing PowerShell (ex. PS 5) flattening of single element
+        if (-not ($pathEntries -is [array])) { $pathEntries = [string[]] @( $pathEntries ) }
+    }
+
+    # $insertafteridx should always be ...
+    # -1: insert at position 0 (before every other entry)
+    #  0: insert at position 1 (after position 0)
+    # +n: insert immediately after position n
+    $acceptable_idxs = [int[]] @(-1)
+    if ($MustBeAfterEntryIfExists) {
+        # we want the last (max) entry, especially if both DOS 8.3 and full directory are in the PATH
+        $insertafteridx = [array]::LastIndexOf($pathEntries, $MustBeAfterEntryIfExists)
+        if ($insertafteridx -ge 0) {
+            [int[]] $acceptable_idxs = $acceptable_idxs + $insertafteridx
+        }
+        $insertafteridx = [array]::LastIndexOf($pathEntries, (Get-Dos83ShortName $MustBeAfterEntryIfExists))
+        if ($insertafteridx -ge 0) {
+            [int[]] $acceptable_idxs = $acceptable_idxs + $insertafteridx
+        }
+    }
+    $insertafteridx = ($acceptable_idxs | Measure-Object -Maximum).Maximum
+
+    # Do the insert
+    if ($insertafteridx -eq -1) {
+        [string[]] $pathEntries = @( $PathEntry ) + $pathEntries
+    }
+    elseif ($insertafteridx -eq $pathEntries.Length - 1) {
+        [string[]] $pathEntries = $pathEntries + @( $PathEntry )
+    }
+    else {
+        $left = 0..($insertafteridx)
+        $right = ($insertafteridx + 1)..($pathEntries.Length-1)
+        [string[]] $pathEntries = $pathEntries[$left + @( $insertafteridx ) + $right]
+        $pathEntries[$insertafteridx + 1] = $PathEntry
+    }
+
+    # Return without unwrapping of arrays. Confer: https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-arrays?view=powershell-7.3#return-an-array
+    Write-Output -NoEnumerate ($pathEntries -join $splitter)
+}
+Export-ModuleMember -Function Join-EnvPathEntry


### PR DESCRIPTION
This PR makes sure that the ordinary `opam.exe` (the one from the main branch of github.com/ocaml/opam) is placed in the PATH after any DKML `opam.exe`.

DKML `opam.exe` is actually a shim that modifies the PATH before executing the "real" `opam.exe` (it does other things as well that aren't relevant for this PR). Historically the real `opam.exe` is in the same directory; it is named `opam-real.exe`. In another PR we'll change that logic so that the `opam.exe` shim searches first for `$env:LOCALAPPDATA\Programs\opam\bin\opam.exe` first, and then `opam-real.exe`.

All of this is a temporary workaround until opam removes Unix-only commands like `cp`.

Testing:
1. PowerShell unit tests (Pester) are included.
2. Tested on my desktop and my messy PATH is modified as such (newlines inserted for readability; the shim opam is at `C:\Users\beckf\AppData\Local\Programs\DISKUV~1\0\bin\opam.exe`):

```
C:\Users\beckf\AppData\Local\Programs\DISKUV~1\0\bin;
C:\Users\beckf\AppData\Local\Programs\DISKUV~1\0\usr\bin;
C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\bin;
C:\Users\beckf\AppData\Local\Programs\opam\bin;
C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\usr\bin;
C:\Users\beckf\.cargo\bin;
C:\Users\beckf\AppData\Local\Microsoft\WindowsApps;
C:\Users\beckf\AppData\Roaming\npm;
...
```
